### PR TITLE
Fix streaming OCR dispatcher to batch by download count

### DIFF
--- a/config/caribbean.yaml
+++ b/config/caribbean.yaml
@@ -27,7 +27,9 @@ download:
 
 # OCR phase settings
 ocr:
-  max_pages_per_chunk: 1500
+  max_pdfs_per_chunk: 200
+  # Legacy fallback for page-count based chunking
+  # max_pages_per_chunk: 1500
   workers: auto
   pages_per_group: auto
   max_wait_hours: 12

--- a/config/pipeline_config.yaml.example
+++ b/config/pipeline_config.yaml.example
@@ -36,8 +36,10 @@ download:
 
 # OCR phase settings (passed to olmocr scripts)
 ocr:
-  # Maximum pages per SLURM job chunk
-  max_pages_per_chunk: 1500
+  # Maximum PDFs to bundle into a single SLURM job chunk
+  max_pdfs_per_chunk: 200
+  # Legacy fallback for page-count based chunking (ignored when max_pdfs_per_chunk is set)
+  # max_pages_per_chunk: 1500
   # Workers (auto = let olmOCR decide)
   workers: auto
   # Pages per group (auto = let olmOCR decide)

--- a/config/production_saskatchewan.yaml
+++ b/config/production_saskatchewan.yaml
@@ -27,7 +27,9 @@ download:
 
 # OCR phase settings
 ocr:
-  max_pages_per_chunk: 1500
+  max_pdfs_per_chunk: 200
+  # Legacy fallback for page-count based chunking
+  # max_pages_per_chunk: 1500
   workers: auto
   pages_per_group: auto
   max_wait_hours: 24  # Allow up to 24 hours for OCR jobs

--- a/config/test_saskatchewan.yaml
+++ b/config/test_saskatchewan.yaml
@@ -29,7 +29,9 @@ download:
 
 # OCR phase settings
 ocr:
-  max_pages_per_chunk: 1500
+  max_pdfs_per_chunk: 200
+  # Legacy fallback for page-count based chunking
+  # max_pages_per_chunk: 1500
   workers: auto
   pages_per_group: auto
   max_wait_hours: 12

--- a/streaming/stream_orchestrator.py
+++ b/streaming/stream_orchestrator.py
@@ -116,7 +116,9 @@ class StreamOrchestrator:
         olmocr_script = olmocr_repo / "smart_submit_pdf_jobs.sh"
 
         ocr_cfg = self.config.get("ocr", {})
-        pages_per_chunk = ocr_cfg.get("max_pages_per_chunk", 1000)
+        pdfs_per_chunk = ocr_cfg.get("max_pdfs_per_chunk")
+        if pdfs_per_chunk is None:
+            pdfs_per_chunk = ocr_cfg.get("max_pages_per_chunk", 200)
 
         cmd = [
             "python3",
@@ -125,7 +127,7 @@ class StreamOrchestrator:
             "--download-queue", str(download_queue),
             "--ocr-processing", str(ocr_processing),
             "--olmocr-script", str(olmocr_script),
-            "--pages-per-chunk", str(pages_per_chunk),
+            "--pdfs-per-chunk", str(pdfs_per_chunk),
             "--check-interval", "60"
         ]
 


### PR DESCRIPTION
## Summary
- update the streaming OCR dispatcher to trigger jobs once a PDF-count threshold is met and keep a compatibility flag for the old argument
- pass the new threshold from the orchestrator while still accepting legacy configuration keys
- document the `max_pdfs_per_chunk` option across sample and production configuration files

## Testing
- python -m compileall streaming

------
https://chatgpt.com/codex/tasks/task_e_68e92c078d44833188224f1c115ee4a1